### PR TITLE
Fetch GitHub results server side, cache for 24h.

### DIFF
--- a/www/ui/src/pages/CodePage.tsx
+++ b/www/ui/src/pages/CodePage.tsx
@@ -92,21 +92,9 @@ class CodePage extends React.Component<{}, Partial<State>> {
   async load() {
     this.setState(() => ({ isFetching: true, error: null }));
 
-    const q: { [key: string]: string } = {
-      org: "govau",
-      topic: "govau-author-cga",
-      fork: "true"
-    };
-
-    const qs = Object.keys(q)
-      .map(k => `${k}:${q[k]}`)
-      .join(" ");
-
     try {
       const resp = await fetch(
-        `https://api.github.com/search/repositories?q=${encodeURIComponent(
-          qs
-        )}`,
+        `/api/github-repos`,
         {
           headers: {
             Accept: "application/vnd.github.v3+json"


### PR DESCRIPTION
This is so that clients that don't support TLS1.2 (as required by GitHub) can access this page.

@jonathaningram  - I'm going to merge this anyway as we're a bit time sensitive and hope that CI does it's thing.

Maybe post-review it later? :)