### PR TITLE
Return application/json type instead

### DIFF
--- a/www/server.go
+++ b/www/server.go
@@ -94,7 +94,7 @@ func (s *Server) getGithubStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/vnd.github.v3+json")
+	w.Header().Set("Content-Type", "application/json")
 	w.Write(bb)
 }
 


### PR DESCRIPTION
This would seem to match what the GitHub API does and we hope this will give better compatibility with IE.