### PR TITLE
Retirement content changes

### DIFF
--- a/www/ui/src/components/Disclaimer.tsx
+++ b/www/ui/src/components/Disclaimer.tsx
@@ -33,42 +33,9 @@ const StyledDisclaimer = styled.div`
     `};
 `;
 
-const RetiringTag = styled.span`
-  ${({ theme }) =>
-  css`
-    background-color: #000;
-    color: #ffffff;
-    font-weight: bold;
-    vertical-align: middle;
-    padding:3px;
-  `};
-`;
-
-const StyledRetiring = styled.div`
-  ${({ theme }) =>
-    css`
-      background-color: #45c2f0;
-    `};
-`;
-
 interface Props {}
 
 const Disclaimer: React.StatelessComponent<Props> = () => (
-  <>
-    <StyledRetiring>
-      <Container>
-        <Flex wrap={true} pt={1} pb={1}>
-          <Box w={[1, "auto"]} pr={2}>
-            <BrandLink href="/">
-              <RetiringTag>Important</RetiringTag>
-            </BrandLink>
-          </Box>
-          <Box w={[1, "auto"]} mt={[1, 0]}>
-            <Official>Cloud.gov.au will be decommissioned by September 2021. Contact our <a href="mailto:support@cloud.gov.au">support</a> team for any questions.</Official>
-          </Box>
-        </Flex>
-      </Container>
-    </StyledRetiring>
     <StyledDisclaimer>
       <Container>
         <Flex wrap={true} pt={1} pb={1}>
@@ -84,7 +51,6 @@ const Disclaimer: React.StatelessComponent<Props> = () => (
         </Flex>
       </Container>
     </StyledDisclaimer>
-  </>
 );
 
 export default Disclaimer;

--- a/www/ui/src/components/Disclaimer.tsx
+++ b/www/ui/src/components/Disclaimer.tsx
@@ -36,21 +36,21 @@ const StyledDisclaimer = styled.div`
 interface Props {}
 
 const Disclaimer: React.StatelessComponent<Props> = () => (
-    <StyledDisclaimer>
-      <Container>
-        <Flex wrap={true} pt={1} pb={1}>
-          <Box w={[1, "auto"]} pr={2}>
-            <BrandLink href="/">
-              <Star src={star} alt="" />
-              <Brand>GOV.AU</Brand>
-            </BrandLink>
-          </Box>
-          <Box w={[1, "auto"]} mt={[1, 0]}>
-            <Official>Official Australian Government website</Official>
-          </Box>
-        </Flex>
-      </Container>
-    </StyledDisclaimer>
+  <StyledDisclaimer>
+    <Container>
+      <Flex wrap={true} pt={1} pb={1}>
+        <Box w={[1, "auto"]} pr={2}>
+          <BrandLink href="/">
+            <Star src={star} alt="" />
+            <Brand>GOV.AU</Brand>
+          </BrandLink>
+        </Box>
+        <Box w={[1, "auto"]} mt={[1, 0]}>
+          <Official>Official Australian Government website</Official>
+        </Box>
+      </Flex>
+    </Container>
+  </StyledDisclaimer>
 );
 
 export default Disclaimer;

--- a/www/ui/src/components/FooterLinks.tsx
+++ b/www/ui/src/components/FooterLinks.tsx
@@ -32,9 +32,6 @@ const FooterLinks: React.StatelessComponent<Props> = () => (
     <Li>
       <Link href="https://console.system.y.cld.gov.au/">Staging console</Link>
     </Li>
-    <Li>
-      <Link to="/terms-of-service/">Terms of service</Link>
-    </Li>
   </Ul>
 );
 

--- a/www/ui/src/components/HeaderLinks.tsx
+++ b/www/ui/src/components/HeaderLinks.tsx
@@ -45,13 +45,7 @@ interface Props {}
 const HeaderLinks: React.StatelessComponent<Props> = () => (
   <Ul>
     <Li>
-      <Link to="/code/">Code</Link>
-    </Li>
-    <Li>
       <Link href="https://docs.cloud.gov.au/">Docs</Link>
-    </Li>
-    <Li>
-      <Link href="https://support.cloud.gov.au/">Support</Link>
     </Li>
   </Ul>
 );

--- a/www/ui/src/components/__snapshots__/Disclaimer.test.tsx.snap
+++ b/www/ui/src/components/__snapshots__/Disclaimer.test.tsx.snap
@@ -1,79 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders without crashing 1`] = `
-Array [
-  .c1 {
-  max-width: 1024px;
-}
-
-.c2 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c4 {
-  color: #ffffff;
-  vertical-align: middle;
-}
-
-.c3 {
-  background-color: #000;
-  color: #ffffff;
-  font-weight: bold;
-  vertical-align: middle;
-  padding: 3px;
-}
-
 .c0 {
-  background-color: #45c2f0;
-}
-
-<div
-    className="c0"
->
-    <div
-        className="c1 sc-bdVaJa bNqJOV"
-        is={null}
-    >
-        <div
-            className="jtWIOA ikjdog"
-            is={null}
-        >
-            <div
-                className="fOpQaR"
-                is={null}
-            >
-                <a
-                    className="c2"
-                    href="/"
-                >
-                    <span
-                        className="c3"
-                    >
-                        Important
-                    </span>
-                </a>
-            </div>
-            <div
-                className="irQXag"
-                is={null}
-            >
-                <span
-                    className="c4"
-                >
-                    Cloud.gov.au will be decommissioned by September 2021. Contact our 
-                    <a
-                        href="mailto:support@cloud.gov.au"
-                    >
-                        support
-                    </a>
-                     team for any questions.
-                </span>
-            </div>
-        </div>
-    </div>
-</div>,
-  .c0 {
   max-width: 1024px;
 }
 
@@ -100,60 +28,59 @@ Array [
 }
 
 <div
-    className=""
+  className=""
 >
+  <div
+    className="c0 sc-bdVaJa bNqJOV"
+    is={null}
+  >
     <div
-        className="c0 sc-bdVaJa bNqJOV"
-        is={null}
+      className="jtWIOA ikjdog"
+      is={null}
     >
-        <div
-            className="jtWIOA ikjdog"
-            is={null}
+      <div
+        className="fOpQaR"
+        is={null}
+      >
+        <a
+          className="c1"
+          href="/"
         >
-            <div
-                className="fOpQaR"
-                is={null}
-            >
-                <a
-                    className="c1"
-                    href="/"
-                >
-                    <img
-                        alt=""
-                        className="c2"
-                        src={
-                            Object {
-                                "0": "s",
-                                "1": "t",
-                                "2": "a",
-                                "3": "r",
-                                "4": ".",
-                                "5": "s",
-                                "6": "v",
-                                "7": "g",
-                                "default": "star.svg",
-                              }
-                        }
-                    />
-                    <span
-                        className="c3"
-                    >
-                        GOV.AU
-                    </span>
-                </a>
-            </div>
-            <div
-                className="irQXag"
-                is={null}
-            >
-                <span
-                    className="c4"
-                >
-                    Official Australian Government website
-                </span>
-            </div>
-        </div>
+          <img
+            alt=""
+            className="c2"
+            src={
+              Object {
+                "0": "s",
+                "1": "t",
+                "2": "a",
+                "3": "r",
+                "4": ".",
+                "5": "s",
+                "6": "v",
+                "7": "g",
+                "default": "star.svg",
+              }
+            }
+          />
+          <span
+            className="c3"
+          >
+            GOV.AU
+          </span>
+        </a>
+      </div>
+      <div
+        className="irQXag"
+        is={null}
+      >
+        <span
+          className="c4"
+        >
+          Official Australian Government website
+        </span>
+      </div>
     </div>
-</div>,
-]
+  </div>
+</div>
 `;

--- a/www/ui/src/components/__snapshots__/Footer.test.tsx.snap
+++ b/www/ui/src/components/__snapshots__/Footer.test.tsx.snap
@@ -13,14 +13,6 @@ exports[`renders without crashing 1`] = `
   border-bottom: solid 1px;
 }
 
-.c6 {
-  -webkit-transition: 0.25s;
-  transition: 0.25s;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: solid 1px;
-}
-
 .c3 {
   margin: 0;
   padding: 0;
@@ -126,17 +118,6 @@ exports[`renders without crashing 1`] = `
               href="https://console.system.y.cld.gov.au/"
             >
               Staging console
-            </a>
-          </li>
-          <li
-            className="c4"
-          >
-            <a
-              className="c6"
-              href="/terms-of-service/"
-              onClick={[Function]}
-            >
-              Terms of service
             </a>
           </li>
         </ul>

--- a/www/ui/src/components/__snapshots__/FooterLinks.test.tsx.snap
+++ b/www/ui/src/components/__snapshots__/FooterLinks.test.tsx.snap
@@ -9,14 +9,6 @@ exports[`renders without crashing 1`] = `
   border-bottom: solid 1px;
 }
 
-.c3 {
-  -webkit-transition: 0.25s;
-  transition: 0.25s;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: solid 1px;
-}
-
 .c0 {
   margin: 0;
   padding: 0;
@@ -49,17 +41,6 @@ exports[`renders without crashing 1`] = `
       href="https://console.system.y.cld.gov.au/"
     >
       Staging console
-    </a>
-  </li>
-  <li
-    className="c1"
-  >
-    <a
-      className="c3"
-      href="/terms-of-service/"
-      onClick={[Function]}
-    >
-      Terms of service
     </a>
   </li>
 </ul>

--- a/www/ui/src/components/__snapshots__/Header.test.tsx.snap
+++ b/www/ui/src/components/__snapshots__/Header.test.tsx.snap
@@ -151,53 +151,10 @@ exports[`renders without crashing 1`] = `
             }
           >
             <a
-              className="c5"
-              href="/code/"
-              onClick={[Function]}
-            >
-              Code
-            </a>
-          </li>
-          <li
-            className="c8"
-            display={
-              Array [
-                "block",
-                "inline-block",
-              ]
-            }
-            m={
-              Array [
-                1,
-              ]
-            }
-          >
-            <a
               className="c9"
               href="https://docs.cloud.gov.au/"
             >
               Docs
-            </a>
-          </li>
-          <li
-            className="c8"
-            display={
-              Array [
-                "block",
-                "inline-block",
-              ]
-            }
-            m={
-              Array [
-                1,
-              ]
-            }
-          >
-            <a
-              className="c9"
-              href="https://support.cloud.gov.au/"
-            >
-              Support
             </a>
           </li>
         </ul>

--- a/www/ui/src/components/__snapshots__/HeaderLinks.test.tsx.snap
+++ b/www/ui/src/components/__snapshots__/HeaderLinks.test.tsx.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders without crashing 1`] = `
-.c3 {
-  -webkit-transition: 0.25s;
-  transition: 0.25s;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: solid 1px;
-}
-
 .c2 {
   -webkit-transition: 0.25s;
   transition: 0.25s;
@@ -53,52 +45,9 @@ exports[`renders without crashing 1`] = `
   >
     <a
       className="c2"
-      href="/code/"
-      onClick={[Function]}
-    >
-      Code
-    </a>
-  </li>
-  <li
-    className="c1"
-    display={
-      Array [
-        "block",
-        "inline-block",
-      ]
-    }
-    m={
-      Array [
-        1,
-      ]
-    }
-  >
-    <a
-      className="c3"
       href="https://docs.cloud.gov.au/"
     >
       Docs
-    </a>
-  </li>
-  <li
-    className="c1"
-    display={
-      Array [
-        "block",
-        "inline-block",
-      ]
-    }
-    m={
-      Array [
-        1,
-      ]
-    }
-  >
-    <a
-      className="c3"
-      href="https://support.cloud.gov.au/"
-    >
-      Support
     </a>
   </li>
 </ul>

--- a/www/ui/src/pages/HomePage.tsx
+++ b/www/ui/src/pages/HomePage.tsx
@@ -7,7 +7,6 @@ import Container from "../components/Container";
 import Link from "../components/Link";
 import Header from "../components/HomePage/Header";
 
-
 const Content = styled.div`
   ${({ theme }) =>
     css`
@@ -54,16 +53,30 @@ const HomePage: React.StatelessComponent = () => (
           </Flex>
           <Flex wrap={true} px={2} pt={0} pb={4}>
             <FeatureP>
-              The cloud.gov.au platform closed on 30 September 2021 and no longer provides whole-of-government hosting services.
+              The cloud.gov.au platform closed on 30 September 2021 and no
+              longer provides whole-of-government hosting services.
             </FeatureP>
             <FeatureP>
-              All materials created while the service was in operation can be found in our <Link href="https://github.com/govau">GitHub open-source code</Link> repository.
+              All materials created while the service was in operation can be
+              found in our{" "}
+              <Link href="https://github.com/govau">
+                GitHub open-source code
+              </Link>{" "}
+              repository.
             </FeatureP>
             <FeatureP>
-              Information about cloud.gov.au can be found on the <Link href="https://www.dta.gov.au/our-projects/about-cloudgovau">Digital Transformation Agency website</Link>.
+              Information about cloud.gov.au can be found on the{" "}
+              <Link href="https://www.dta.gov.au/our-projects/about-cloudgovau">
+                Digital Transformation Agency website
+              </Link>
+              .
             </FeatureP>
             <FeatureP>
-              To source cloud services for government, please visit the <Link href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616">Cloud Marketplace</Link>.
+              To source cloud services for government, please visit the{" "}
+              <Link href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616">
+                Cloud Marketplace
+              </Link>
+              .
             </FeatureP>
           </Flex>
         </Container>

--- a/www/ui/src/pages/HomePage.tsx
+++ b/www/ui/src/pages/HomePage.tsx
@@ -48,30 +48,23 @@ const HomePage: React.StatelessComponent = () => (
           <Flex wrap={true} px={2} pt={3} pb={0}>
             <Box w={[1, 1]} pt={[1, 1]} pr={[0, 1]}>
               <FeatureHeading>
-                Cloud.gov.au will be decommissioned
+                Cloud.gov.au has been decommissioned
               </FeatureHeading>
             </Box>
           </Flex>
           <Flex wrap={true} px={2} pt={0} pb={4}>
-            <Box w={[1, 1 / 2]} pt={[1, 1]} pb={[1, 3]} pr={[0, 3]}>
-              <FeatureP>
-                The cloud.gov.au platform is being decommissioned by the DTA and will no longer provide whole-of-government hosting services. 
-              </FeatureP>
-              <FeatureP>
-                We appreciate your support of the cloud.gov.au platform. The DTA will contact current users of the platform and provide more information.
-              </FeatureP>
-            </Box>
-            <Box w={[1, 1 / 2]} pt={[1, 1]} pb={[1, 3]} pr={[0, 3]}>
-              <FeatureP>
-                For further details or if you have any questions, please contact our support team at <Link href="mailto:support@cloud.gov.au">support@cloud.gov.au</Link>.
-              </FeatureP>
-              <FeatureP>
-                To source a Cloud platform and cloud services for government, please <Link href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616">visit the Cloud Marketplace</Link>.
-              </FeatureP>
-              <FeatureP>
-                Thank you for your support of Cloud.gov.au.
-              </FeatureP>
-            </Box>
+            <FeatureP>
+              The cloud.gov.au platform closed on 30 September 2021 and no longer provides whole-of-government hosting services.
+            </FeatureP>
+            <FeatureP>
+              All materials created while the service was in operation can be found in our <Link href="https://github.com/govau">GitHub open-source code</Link> repository.
+            </FeatureP>
+            <FeatureP>
+              Information about cloud.gov.au can be found on the <Link href="https://www.dta.gov.au/our-projects/about-cloudgovau">Digital Transformation Agency website</Link>.
+            </FeatureP>
+            <FeatureP>
+              To source cloud services for government, please visit the <Link href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616">Cloud Marketplace</Link>.
+            </FeatureP>
           </Flex>
         </Container>
       </Ribbon1>

--- a/www/ui/src/pages/__snapshots__/HomePage.test.tsx.snap
+++ b/www/ui/src/pages/__snapshots__/HomePage.test.tsx.snap
@@ -105,7 +105,7 @@ Array [
                     <h2
                         className="c3"
                     >
-                        Cloud.gov.au will be decommissioned
+                        Cloud.gov.au has been decommissioned
                     </h2>
                 </div>
             </div>
@@ -113,55 +113,47 @@ Array [
                 className="jtWIOA glmugy"
                 is={null}
             >
-                <div
-                    className="bEJPeE"
-                    is={null}
+                <p
+                    className="c4"
                 >
-                    <p
-                        className="c4"
-                    >
-                        The cloud.gov.au platform is being decommissioned by the DTA and will no longer provide whole-of-government hosting services.
-                    </p>
-                    <p
-                        className="c4"
-                    >
-                        We appreciate your support of the cloud.gov.au platform. The DTA will contact current users of the platform and provide more information.
-                    </p>
-                </div>
-                <div
-                    className="bEJPeE"
-                    is={null}
+                    The cloud.gov.au platform closed on 30 September 2021 and no longer provides whole-of-government hosting services.
+                </p>
+                <p
+                    className="c4"
                 >
-                    <p
-                        className="c4"
+                    All materials created while the service was in operation can be found in our 
+                    <a
+                        className="c5"
+                        href="https://github.com/govau"
                     >
-                        For further details or if you have any questions, please contact our support team at 
-                        <a
-                            className="c5"
-                            href="mailto:support@cloud.gov.au"
-                        >
-                            support@cloud.gov.au
-                        </a>
-                        .
-                    </p>
-                    <p
-                        className="c4"
+                        GitHub open-source code
+                    </a>
+                     repository.
+                </p>
+                <p
+                    className="c4"
+                >
+                    Information about cloud.gov.au can be found on the 
+                    <a
+                        className="c5"
+                        href="https://www.dta.gov.au/our-projects/about-cloudgovau"
                     >
-                        To source a Cloud platform and cloud services for government, please 
-                        <a
-                            className="c5"
-                            href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616"
-                        >
-                            visit the Cloud Marketplace
-                        </a>
-                        .
-                    </p>
-                    <p
-                        className="c4"
+                        Digital Transformation Agency website
+                    </a>
+                    .
+                </p>
+                <p
+                    className="c4"
+                >
+                    To source cloud services for government, please visit the 
+                    <a
+                        className="c5"
+                        href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616"
                     >
-                        Thank you for your support of Cloud.gov.au.
-                    </p>
-                </div>
+                        Cloud Marketplace
+                    </a>
+                    .
+                </p>
             </div>
         </div>
     </section>

--- a/www/ui/src/pages/__snapshots__/HomePage.test.tsx.snap
+++ b/www/ui/src/pages/__snapshots__/HomePage.test.tsx.snap
@@ -121,19 +121,22 @@ Array [
                 <p
                     className="c4"
                 >
-                    All materials created while the service was in operation can be found in our 
+                    All materials created while the service was in operation can be found in our
+                     
                     <a
                         className="c5"
                         href="https://github.com/govau"
                     >
                         GitHub open-source code
                     </a>
-                     repository.
+                     
+                    repository.
                 </p>
                 <p
                     className="c4"
                 >
-                    Information about cloud.gov.au can be found on the 
+                    Information about cloud.gov.au can be found on the
+                     
                     <a
                         className="c5"
                         href="https://www.dta.gov.au/our-projects/about-cloudgovau"
@@ -145,7 +148,8 @@ Array [
                 <p
                     className="c4"
                 >
-                    To source cloud services for government, please visit the 
+                    To source cloud services for government, please visit the
+                     
                     <a
                         className="c5"
                         href="https://www.buyict.gov.au/sp?id=buyer&kb=KB0010616"


### PR DESCRIPTION
This pull request:
- Removes the banner warning users about cloud.gov.au being decommissioned
- Removes the `Code` and `Support` links from the header
- Updates the home page content
- Removes the `Terms of service` link from the footer